### PR TITLE
Revert "Merge pull request #10 from Financial-Times/add-uniq-index"

### DIFF
--- a/mongorw.go
+++ b/mongorw.go
@@ -69,7 +69,6 @@ func (ma *mgoAPI) EnsureIndex() {
 	index := mgo.Index{
 		Key:        []string{"uuid"},
 		Background: true,
-		Unique:     true,
 	}
 
 	for coll := range ma.collections {


### PR DESCRIPTION
This reverts commit 0427e1d4a832f81f3b5d000a3f45c1c886b8ceed, reversing
changes made to 484b57e7f0b79fde0674555db3ab114cef64daa9.

* we need to do this before nativerw can be released, we're not ready to release this yet