### PR TITLE
Improve error handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,21 @@
-FROM gliderlabs/alpine:3.2
-ADD nativerw config.json /
-EXPOSE 8080
+FROM alpine:3.3
 
-CMD /nativerw -mongos=$MONGO_ADDRESSES config.json
+ADD *.go /nativerw/
+ADD config.json /nativerw/
 
+RUN apk add --update bash \
+  && apk --update add git bzr \
+  && apk --update add go \
+  && export GOPATH=/gopath \
+  && REPO_PATH="github.com/Financial-Times/nativerw" \
+  && mkdir -p $GOPATH/src/${REPO_PATH} \
+  && mv nativerw/* $GOPATH/src/${REPO_PATH} \
+  && cd $GOPATH/src/${REPO_PATH} \
+  && go get -t ./... \
+  && go build \
+  && mv nativerw /nativerw-app \
+  && mv config.json /config.json \
+  && apk del go git bzr \
+  && rm -rf $GOPATH /var/cache/apk/*
+
+CMD [ "/nativerw-app" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,6 @@
-FROM alpine:3.3
+FROM gliderlabs/alpine:3.2
+ADD nativerw config.json /
+EXPOSE 8080
 
-ADD *.go /nativerw/
-ADD config.json /nativerw/
+CMD /nativerw -mongos=$MONGO_ADDRESSES config.json
 
-RUN apk add --update bash \
-  && apk --update add git bzr \
-  && apk --update add go \
-  && export GOPATH=/gopath \
-  && REPO_PATH="github.com/Financial-Times/nativerw" \
-  && mkdir -p $GOPATH/src/${REPO_PATH} \
-  && mv nativerw/* $GOPATH/src/${REPO_PATH} \
-  && cd $GOPATH/src/${REPO_PATH} \
-  && go get -t ./... \
-  && go build \
-  && mv nativerw /nativerw-app \
-  && mv config.json /config.json \
-  && apk del go git bzr \
-  && rm -rf $GOPATH /var/cache/apk/*
-
-CMD [ "/nativerw-app" ]

--- a/nativerw.go
+++ b/nativerw.go
@@ -61,7 +61,6 @@ func main() {
 		}
 	}
 	err := cliApp.Run(os.Args)
-
 	if err != nil {
 		println(err)
 	}

--- a/nativerw.go
+++ b/nativerw.go
@@ -9,6 +9,7 @@ import (
 	fthealth "github.com/Financial-Times/go-fthealth"
 	"github.com/gorilla/mux"
 	"github.com/jawher/mow.cli"
+	"github.com/kr/pretty"
 )
 
 func main() {
@@ -37,6 +38,7 @@ func main() {
 			config.Mongos = *mongos
 		}
 
+		logger.info(fmt.Sprintf("Using configuration %# v \n", pretty.Formatter(config)))
 		mgoAPI, mgoAPICreationErr := newMgoAPI(config)
 		for mgoAPICreationErr != nil {
 			logger.error(fmt.Sprintf("Couldn't establish connection to mongoDB: %+v", mgoAPICreationErr.Error()))

--- a/nativerw.go
+++ b/nativerw.go
@@ -33,16 +33,12 @@ func main() {
 	}
 
 	mgoAPI, mgoAPICreationErr := newMgoAPI(config)
-	for {
-		if mgoAPICreationErr != nil {
-			logger.error(fmt.Sprintf("Couldn't establish connection to mongoDB: %+v", mgoAPICreationErr.Error()))
-			time.Sleep(5 * time.Second)
-			mgoAPI, mgoAPICreationErr = newMgoAPI(config)
-		} else {
-			logger.info("Established connection to mongoDB.")
-			break
-		}
+	for mgoAPICreationErr != nil {
+		logger.error(fmt.Sprintf("Couldn't establish connection to mongoDB: %+v", mgoAPICreationErr.Error()))
+		time.Sleep(5 * time.Second)
+		mgoAPI, mgoAPICreationErr = newMgoAPI(config)
 	}
+	logger.info("Established connection to mongoDB.")
 
 	mgoAPI.EnsureIndex()
 


### PR DESCRIPTION
* exit with an non-zero error code in case of fatal errors -> unit will be considered failed and auto-restarted instead of inactive as it happens now
* infinite loop to try to connect to the mongos
  * this handles the case where the mongo configs were read correctly at the beginning but the mongos themselves aren't up yet 