### PR TITLE
Reapplying unique index on uuid field of native-store collections

### DIFF
--- a/mongorw.go
+++ b/mongorw.go
@@ -69,6 +69,7 @@ func (ma *mgoAPI) EnsureIndex() {
 	index := mgo.Index{
 		Key:        []string{"uuid"},
 		Background: true,
+		Unique:     true,
 	}
 
 	for coll := range ma.collections {


### PR DESCRIPTION
**Note**: the index was manually applied already in PUB-PRE-PROD and PUB-PROD clusters.