### PR TITLE
Fix/mongo reconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,9 @@ docker build -t coco/nativerw .
 ```
 
 ## Running
-
-`$GOPATH/bin/nativerw $GOPATH/src/github.com/Financial-Times/nativerw/config.json`
-
-You can override the mongos with -mongos flag, e.g.
-
-`$GOPATH/bin/nativerw -mongos=mongo1:port,mongo2:port $GOPATH/src/github.com/Financial-Times/nativerw/config.json`
+The following params can be injected in the nativerw app on startup through environment variables:
+ - `MONGOS` This env var is mandatory. Mongo addresses to connect to in format: host1[:port1][,host2[:port2],...] the app will exit (with `exit code 1`) if it is not set.
+ - `CONFIG` Config file in json format. If not set, the default `config.json` will be used.
 
 ## API
 

--- a/app.go
+++ b/app.go
@@ -41,7 +41,7 @@ func main() {
 		}
 
 		if len(*mongos) == 0 {
-			logging.Error("Not mongo paths specified.")
+			logging.Error("No mongo paths specified")
 			os.Exit(1)
 		}
 

--- a/app.go
+++ b/app.go
@@ -40,9 +40,12 @@ func main() {
 			os.Exit(1)
 		}
 
-		if len(*mongos) != 0 {
-			conf.Mongos = *mongos
+		if len(*mongos) == 0 {
+			logging.Error("Not mongo paths specified.")
+			os.Exit(1)
 		}
+
+		conf.Mongos = *mongos
 
 		logging.Info(fmt.Sprintf("Using configuration %# v \n", pretty.Formatter(conf)))
 

--- a/config.json
+++ b/config.json
@@ -1,5 +1,4 @@
 {
-   "mongos": "localhost:27017",
    "server": {
       "port": "8080"
    },


### PR DESCRIPTION
The problem:
 - The sidekick of a service sets the following entry in etcd: ft/config/<service-name>/host <HOST_VALUE> on strartup and deletes it when the service is stopped. In the case of nativerw, the service reads this etcd entry on start up and if it is not set, it defaults to localhost. Consequently, when starting nativerw in one of the COCO clusters and mongo instances are stopped, the ft/config/mongodb-x/host etcd entry is not set and the path to mongos will default to localhost instead of the ones from cluster.

The fix:
- If no mongo paths are provided, stop the app with exit code 1 so in coco clusters it will restart until it gets the right mongo paths.