### PR TITLE
Fixed the case when nativerw starts during mongo startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ docker build -t coco/nativerw .
 
 ## Running
 The following params can be injected in the nativerw app on startup through environment variables:
- - `MONGOS` This env var is mandatory. Mongo addresses to connect to in format: host1[:port1][,host2[:port2],...] the app will exit (with `exit code 1`) if it is not set.
+ - `MONGOS` This env var is mandatory. Mongo addresses to connect to in format: host1:port1[,host2:port2,...] the app will exit (with `exit code 1`) it is not valid. The `MONGOS` value is considered to be valid if the number of provided URLs matches the provided `MONGO_NODE_COUNT` and each MongoDb URL has host:port.
+ - `MONGO_NODE_COUNT` The number of MongoDB instances. Default value is 3.
  - `CONFIG` Config file in json format. If not set, the default `config.json` will be used.
 
 ## API

--- a/app.go
+++ b/app.go
@@ -20,7 +20,7 @@ func main() {
 	mongos := cliApp.String(cli.StringOpt{
 		Name:   "mongos",
 		Value:  "",
-		Desc:   "Mongo addresses to connect to in format: host1:port][,host2:port2,...]",
+		Desc:   "Mongo addresses to connect to in format: host1:port1[,host2:port2,...]",
 		EnvVar: "MONGOS",
 	})
 

--- a/app.go
+++ b/app.go
@@ -20,8 +20,15 @@ func main() {
 	mongos := cliApp.String(cli.StringOpt{
 		Name:   "mongos",
 		Value:  "",
-		Desc:   "Mongo addresses to connect to in format: host1[:port1][,host2[:port2],...]",
+		Desc:   "Mongo addresses to connect to in format: host1:port][,host2:port2,...]",
 		EnvVar: "MONGOS",
+	})
+
+	mongoNodeCount := cliApp.Int(cli.IntOpt{
+		Name:   "mongo_node_count",
+		Value:  3,
+		Desc:   "Number of mongoDB instances",
+		EnvVar: "MONGO_NODE_COUNT",
 	})
 
 	configFile := cliApp.String(cli.StringOpt{
@@ -40,8 +47,8 @@ func main() {
 			os.Exit(1)
 		}
 
-		if len(*mongos) == 0 {
-			logging.Error("No mongo paths specified")
+		if err := db.CheckMongoUrls(*mongos, *mongoNodeCount); err != nil {
+			logging.Error(fmt.Sprintf("Provided mongoDB urls are invalid: %s", err.Error()))
 			os.Exit(1)
 		}
 
@@ -67,7 +74,7 @@ func main() {
 			connection.EnsureIndex()
 		}()
 
-		err = http.ListenAndServe(":"+conf.Server.Port, nil)
+		err = http.ListenAndServe(":" + conf.Server.Port, nil)
 		if err != nil {
 			logging.Error(fmt.Sprintf("Couldn't set up HTTP listener: %+v\n", err))
 		}

--- a/db/mongorw.go
+++ b/db/mongorw.go
@@ -239,7 +239,7 @@ func CheckMongoUrls(providedMongoUrls string, expectedMongoNodeCount int) error 
 		urlComponents := strings.Split(mongoUrl, ":")
 		noOfUrlComponents := len(urlComponents)
 
-		if noOfUrlComponents != 2 {
+		if !(noOfUrlComponents == 2 && urlComponents[0] != "" && urlComponents[1] != ""){
 			return fmt.Errorf("One of the MongoDB URLs is invalid: %s. It should have host and port.", mongoUrl)
 		}
 	}

--- a/db/mongorw.go
+++ b/db/mongorw.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pborman/uuid"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
+	"strings"
 )
 
 const uuidName = "uuid"
@@ -225,4 +226,23 @@ func (ma *mongoConnection) ReadIDs(ctx context.Context, collection string) (chan
 	}()
 
 	return ids, nil
+}
+
+func CheckMongoUrls(providedMongoUrls string, expectedMongoNodeCount int) error {
+	mongoUrls := strings.Split(providedMongoUrls, ",")
+	actualMongoNodeCount := len(mongoUrls)
+	if actualMongoNodeCount != expectedMongoNodeCount {
+		return fmt.Errorf("The provided list of MongoDB URLs should have %d instances, but it has %d instead. Provided MongoDB URLs are: %s", expectedMongoNodeCount, actualMongoNodeCount, providedMongoUrls)
+	}
+
+	for _, mongoUrl := range mongoUrls {
+		urlComponents := strings.Split(mongoUrl, ":")
+		noOfUrlComponents := len(urlComponents)
+
+		if noOfUrlComponents != 2 {
+			return fmt.Errorf("One of the MongoDB URLs is invalid: %s. It should have host and port.", mongoUrl)
+		}
+	}
+
+	return nil
 }

--- a/db/mongorw.go
+++ b/db/mongorw.go
@@ -96,7 +96,7 @@ func (m *mongoDB) Open() (Connection, error) {
 }
 
 func (m *mongoDB) openMongoSession() (*mongoConnection, error) {
-	session, err := mgo.DialWithTimeout(m.config.Mongos, 30*time.Second)
+	session, err := mgo.DialWithTimeout(m.config.Mongos, 30 * time.Second)
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +239,7 @@ func CheckMongoUrls(providedMongoUrls string, expectedMongoNodeCount int) error 
 		urlComponents := strings.Split(mongoUrl, ":")
 		noOfUrlComponents := len(urlComponents)
 
-		if !(noOfUrlComponents == 2 && urlComponents[0] != "" && urlComponents[1] != ""){
+		if noOfUrlComponents != 2 || urlComponents[0] == "" || urlComponents[1] == "" {
 			return fmt.Errorf("One of the MongoDB URLs is invalid: %s. It should have host and port.", mongoUrl)
 		}
 	}

--- a/db/mongorw_test.go
+++ b/db/mongorw_test.go
@@ -266,3 +266,33 @@ func TestCancelReadIDs(t *testing.T) {
 		count++
 	}
 }
+
+func TestCheckMongoUrlsValidUrls(t *testing.T) {
+	err := CheckMongoUrls("host:port,host2:port2", 2)
+
+	assert.Nil(t, err)
+}
+
+func TestCheckMongoUrlsFewerUrlsThanExpected(t *testing.T) {
+	err := CheckMongoUrls("host:port,host2:port2", 3)
+
+	assert.NotNil(t, err)
+}
+
+func TestCheckMongoUrlsMissingPort(t *testing.T) {
+	err := CheckMongoUrls("host:port,host2:", 3)
+
+	assert.NotNil(t, err)
+}
+
+func TestCheckMongoUrlsMissingHost(t *testing.T) {
+	err := CheckMongoUrls("host:port,:port", 3)
+
+	assert.NotNil(t, err)
+}
+
+func TestCheckMongoUrlsInvalidSeparator(t *testing.T) {
+	err := CheckMongoUrls("host:port;host1:port1", 2)
+
+	assert.NotNil(t, err)
+}

--- a/db/mongorw_test.go
+++ b/db/mongorw_test.go
@@ -280,13 +280,13 @@ func TestCheckMongoUrlsFewerUrlsThanExpected(t *testing.T) {
 }
 
 func TestCheckMongoUrlsMissingPort(t *testing.T) {
-	err := CheckMongoUrls("host:port,host2:", 3)
+	err := CheckMongoUrls("host:port,host2:", 2)
 
 	assert.NotNil(t, err)
 }
 
 func TestCheckMongoUrlsMissingHost(t *testing.T) {
-	err := CheckMongoUrls("host:port,:port", 3)
+	err := CheckMongoUrls("host:port,:port", 2)
 
 	assert.NotNil(t, err)
 }


### PR DESCRIPTION
Added MongoDB URLs param validation. 
It is considered to be valid if:
 - the number of provided URLs matches the provided mongoNodeCount
 - each MongoDb URL has host:port

