### PR TITLE
Automatically recreating RUNBOOK.md without relationships [Skip CI]

### DIFF
--- a/runbooks/runbook.md
+++ b/runbooks/runbook.md
@@ -1,3 +1,7 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP - Native read/write
 
 The purpose of this service is to read/write content to and from Mongo native store.
@@ -8,7 +12,7 @@ nativestorereaderwriter
 
 ## Primary URL
 
-<https://upp-prod-publish-glb.upp.ft.com/__nativerw/>
+https://upp-prod-publish-glb.upp.ft.com/__nativerw/
 
 ## Service Tier
 
@@ -17,28 +21,6 @@ Platinum
 ## Lifecycle Stage
 
 Production
-
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- dimitar.terziev
-- hristo.georgiev
-- elitsa.pavlova
-- elina.kaneva
-- kalin.arsov
-- ivan.nikolov
-- miroslav.gatsanoga
-- mihail.mihaylov
-- tsvetan.dimitrov
-- georgi.ivanov
-- robert.marinov
 
 ## Host Platform
 
@@ -57,9 +39,19 @@ No
 
 No
 
-## Dependencies
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
 
-- upp-mongodb
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -102,6 +94,14 @@ the service is deployed to production.
 Otherwise, an automated failover is going to take place when releasing.
 For more details about the failover process please see: <https://github.com/Financial-Times/upp-docs/blob/master/failover-guides/publishing-cluster>
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Key Management Process Type
 
 Manual
@@ -115,8 +115,8 @@ To rotate credentials you need to login to a particular cluster and update varni
 
 Service in UPP K8S Publish clusters:
 
-- Publish-Prod-EU health: <https://upp-prod-publish-eu.ft.com/__health/__pods-health?service-name=nativerw>
-- Publish-Prod-US health: <https://upp-prod-publish-eu.ft.com/__health/__pods-health?service-name=nativerw>
+*   Publish-Prod-EU health: <https://upp-prod-publish-eu.ft.com/__health/__pods-health?service-name=nativerw>
+*   Publish-Prod-US health: <https://upp-prod-publish-eu.ft.com/__health/__pods-health?service-name=nativerw>
 
 ## First Line Troubleshooting
 


### PR DESCRIPTION

## What
 - The [RUNBOOK.md](https://github.com/Financial-Times/nativerw/blob/runbook-no-relationships-2021-03-19/runbooks/runbook.md) file has been automatically regenerated from the Biz Ops data for the **nativestorereaderwriter** system.
 - All the relationships/dependencies have been excluded from RUNBOOK.md but are still in the **nativestorereaderwriter** system in [Biz Ops](https://biz-ops.in.ft.com/System/nativestorereaderwriter).
 - Please continue to manage those relationships/dependencies manually or via the Biz Ops API.

## Why
 - Support for relationships/dependencies within RUNBOOK.md is being removed to avoid the side effects [identified in this proposal](https://docs.google.com/document/d/1njFceyb49TeaIR53Y9r62CenTzdey1fyeJkUvxd9SQQ)
 - This is a prerequisite to the improved ownership/support model [defined in this proposal](https://docs.google.com/document/d/1vTRe7S5dUqIMAoWyqD2pMEkg_5998NCEeFwsxT_k9pw).

## Next Steps
 - Please check and merge this PR.
 - You should only see the removal of the **Delivered By**, **Supported By**, **Technical Owner**, **Known About By**, **Stakeholders**, **Dependencies** and **Healthcheck** sections. Please contact [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) if there are other differences as your current runbook.md file may be inconsistent with Biz Ops.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are unlocking all the relationships/dependencies to re-enable manual/API updates.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are adjusting the rules to allow these simpler RUNBOOK.md files to pass validation.
