### PR TITLE
Add schema-version & content-revision to the response headers

### DIFF
--- a/pkg/resources/read.go
+++ b/pkg/resources/read.go
@@ -128,6 +128,8 @@ func ReadSingleRevision(mongo db.DB) func(w http.ResponseWriter, r *http.Request
 		contentTypeHeader := resource.ContentType
 		w.Header().Add("Content-Type", contentTypeHeader)
 		w.Header().Add("Origin-System-Id", resource.OriginSystemID)
+		w.Header().Add(SchemaVersionHeader, resource.SchemaVersion)
+		w.Header().Add(ContentRevisionHeader, strconv.FormatInt(resource.ContentRevision, 10))
 
 		om, err := mapper.OutMapperForContentType(contentTypeHeader)
 		if err != nil {


### PR DESCRIPTION
# Description

## What

Expose `schema-version` and `content-revision` as part of the response header. Later will be consumed by the native store synchronise script.

## Why

[UPPSF-2248](https://financialtimes.atlassian.net/browse/UPPSF-2248)

## Anything, in particular, you'd like to highlight to reviewers

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [X] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
