### PR TITLE
Feature/uppsf 2247 disable purge in eu

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The following params can be injected in the nativerw app on startup through envi
  - `MONGO_NODE_COUNT` The number of MongoDB instances. Default value is 3.
  - `CONFIG` Config file in json format. If not set, the default `config.json` will be used.
  - `TIDS_TO_SKIP` Regular expression defining transaction-id's to be skipped from storing in nativerw
+ - `DISABLE-PURGE` Disables the `purge` endpoint
 
 ## API
 

--- a/helm/nativerw/app-configs/nativerw_eks_publish_prod_eu.yaml
+++ b/helm/nativerw/app-configs/nativerw_eks_publish_prod_eu.yaml
@@ -2,4 +2,4 @@
 replicaCount: 2
 service:
   name: nativerw
-  disablePurge: "false"
+  disablePurge: "true"

--- a/helm/nativerw/app-configs/nativerw_eks_publish_staging_eu.yaml
+++ b/helm/nativerw/app-configs/nativerw_eks_publish_staging_eu.yaml
@@ -2,4 +2,4 @@
 replicaCount: 2
 service:
   name: nativerw
-  disablePurge: "false"
+  disablePurge: "true"

--- a/helm/nativerw/templates/deployment.yaml
+++ b/helm/nativerw/templates/deployment.yaml
@@ -43,6 +43,8 @@ spec:
               key: mongo.addresses
         - name: TIDS_TO_SKIP
           value: "^(tid_[0-9]+_carousel_[0-9]+_gentx|SYNTHETIC-REQ-MON.+)"
+        - name: DISABLE_PURGE
+          value: "{{ .Values.service.disablePurge }}"
         ports:
         - containerPort: 8080
         livenessProbe:

--- a/helm/nativerw/values.yaml
+++ b/helm/nativerw/values.yaml
@@ -4,6 +4,7 @@
 service:
   name: "" # The name of the service, should be defined in the specific app-configs folder.
   hasHealthcheck: "true"
+  disablePurge: "true"
 replicaCount: 2
 image:
   repository: coco/nativerw


### PR DESCRIPTION
# Description

## What

Introduce `purge` endpoint that will physically delete a document from the DB. Only available in the US cluster.

## Why

[UPPSF-2247](https://financialtimes.atlassian.net/browse/UPPSF-2247)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [X] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
