### PR TITLE
Remove requirement to add content-type on PATCH

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,20 @@ The following params can be injected in the nativerw app on startup through envi
  - `TIDS_TO_SKIP` Regular expression defining transaction-id's to be skipped from storing in nativerw
  - `DISABLE-PURGE` Disables the `purge` endpoint
 
+To run locally against `dev` native store:
+1. Port forward the `main` node
+   
+   `kubectx eks-publish-dev-eu`
+   
+    `kubectl port-forward mongodb-<id> 27017:27017`
+
+2. Run with the required ENV vars
+    
+    bash
+   
+    `
+    MONGOS=localhost:27017 MONGO_NODE_COUNT=1 TIDS_TO_SKIP=none go run cmd/nativerw/main.go
+    `
 ## API
 
 The nativerw supports the following endpoints:

--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -56,7 +56,10 @@ func jsonVariantOutMapper(w io.Writer, resource *Resource) error {
 }
 
 func octetStreamOutMapper(w io.Writer, resource *Resource) error {
-	data := resource.Content.([]byte)
+	data, ok := resource.Content.([]byte)
+	if !ok {
+		return errors.New("error while casting to byte array")
+	}
 	_, err := io.Copy(w, bytes.NewReader(data))
 	return err
 }

--- a/pkg/resources/patch.go
+++ b/pkg/resources/patch.go
@@ -50,7 +50,10 @@ func PatchContent(mongo db.DB, ts TimestampCreator) func(w http.ResponseWriter, 
 			return
 		}
 
-		contentTypeHeader := extractAttrFromHeader(r, "Content-Type", "application/octet-stream", tid, resourceID)
+		contentTypeHeader := extractAttrFromHeader(r, "Content-Type", "", tid, resourceID)
+		if contentTypeHeader == ""{
+			contentTypeHeader = resource.ContentType
+		}
 		inMapper, err := mapper.InMapperForContentType(contentTypeHeader)
 		if err != nil {
 			msg := "Unsupported content-type"

--- a/pkg/resources/patch.go
+++ b/pkg/resources/patch.go
@@ -51,7 +51,7 @@ func PatchContent(mongo db.DB, ts TimestampCreator) func(w http.ResponseWriter, 
 		}
 
 		contentTypeHeader := extractAttrFromHeader(r, "Content-Type", "", tid, resourceID)
-		if contentTypeHeader == ""{
+		if contentTypeHeader == "" {
 			contentTypeHeader = resource.ContentType
 		}
 		inMapper, err := mapper.InMapperForContentType(contentTypeHeader)

--- a/pkg/resources/patch_test.go
+++ b/pkg/resources/patch_test.go
@@ -261,8 +261,6 @@ func TestDefaultContentType(t *testing.T) {
 	path := fmt.Sprintf("/%s/%s", collection, uuid)
 	req, _ := http.NewRequest(httpMethod, path, strings.NewReader(`{"body": "updated-data"}`))
 
-	//req.Header.Add("Content-Type", contentType)
-
 	router.ServeHTTP(w, req)
 	mongo.AssertExpectations(t)
 	assert.Equal(t, http.StatusOK, w.Code)


### PR DESCRIPTION
# Description

Currently content type is required when PATCHing otherwise default `application/octet-stream` is set which breaks content.

## What

If content type is not provided the current one from the native store is being set. 

## Why

https://financialtimes.atlassian.net/secure/RapidBoard.jspa?rapidView=734&modal=detail&selectedIssue=UPPSF-2331&sprint=2242&quickFilter=3411

Please check if the new test added is fine and matches our internal standards.
Please check if the error handing is done in canonical go way

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
