### PR TITLE
Deprecate "v1-metadata" collection

### DIFF
--- a/configs/config.json
+++ b/configs/config.json
@@ -5,7 +5,6 @@
    "dbName": "native-store",
    "collections": [
       "universal-content",
-      "v1-metadata",
       "video",
       "video-metadata",
       "pac-metadata",

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -21,7 +21,7 @@ func TestConfigFromReader(t *testing.T) {
          "collections": [
             "video",
             "universal-content",
-            "v1-metadata"
+            "pac-metadata"
          ]
       }`)
 	config, err := ReadConfigFromReader(reader)
@@ -29,7 +29,7 @@ func TestConfigFromReader(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, randomness, config.Mongos)
 	assert.Equal(t, "native-store", config.DBName)
-	assert.Equal(t, []string{"video", "universal-content", "v1-metadata"}, config.Collections)
+	assert.Equal(t, []string{"video", "universal-content", "pac-metadata"}, config.Collections)
 	assert.Equal(t, 8080, config.Server.Port)
 }
 
@@ -56,7 +56,7 @@ func TestConfigFromFile(t *testing.T) {
          "collections": [
             "video",
             "universal-content",
-            "v1-metadata"
+            "pac-metadata"
          ]
       }`))
 	assert.NoError(t, err)
@@ -66,6 +66,6 @@ func TestConfigFromFile(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, randomness, config.Mongos)
 	assert.Equal(t, "native-store", config.DBName)
-	assert.Equal(t, []string{"video", "universal-content", "v1-metadata"}, config.Collections)
+	assert.Equal(t, []string{"video", "universal-content", "pac-metadata"}, config.Collections)
 	assert.Equal(t, 8080, config.Server.Port)
 }


### PR DESCRIPTION
# Description

After the decommissioning of the v1 Annotations Publishing Pipeline(https://financialtimes.atlassian.net/browse/UPPSF-2317), the "v1-metadata" collection in the Native store is not being used anymore.

## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-2462)

## Anything, in particular, you'd like to highlight to reviewers

_I've incremented the `patch` version of the service._
_Once this PR is approved, I'll merge #76 as well. If I shouldn't do it, please do tell._

## Scope and particulars of this PR (Please tick all that apply)

- [x] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
